### PR TITLE
"todo list" should be same as "todo ls"

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -32,7 +32,7 @@ func defaultFile(name, env string) string {
 const usage = `Usage:
 	todo
 		Show top task
-	todo ls
+	todo ls/list
 		Show all tasks
 	todo N
 		Promote task N to top
@@ -57,7 +57,7 @@ func main() {
 
 	err := noAct
 	switch {
-	case a == "ls" && n == 1:
+	case (a == "ls" || a == "list") && n == 1:
 		// list tasks
 		var tasks []string
 		tasks, err = list.Get()


### PR DESCRIPTION
This is not a really pull-request. Note that my problem won't be fixed with this pull-request.
I'm using this `todo` but sometimes I mistake to list my todo.

![](http://go-gyazo.appspot.com/316367ec2f70ef31.png)

I'm thinking this is because this command-line is not uniformed as human-interactives. So it should change sub-command. For example:
### Require sub command. Not add with "todo foo".

```
$ todo add "foo bar baz"
$ todo list
```
